### PR TITLE
Profiling 过滤架构重构

### DIFF
--- a/colasoft/controller.go
+++ b/colasoft/controller.go
@@ -11,19 +11,40 @@ import (
 	"github.com/toliu/opentelemetry-ebpf-profiler/tracer"
 )
 
+// colasoftFilter implements libpf.ProcessFilter with colasoft's profiling policies.
+type colasoftFilter struct {
+	targetPIDs    libpf.MutablePIDFilter
+	memTargetPIDs libpf.MutablePIDFilter
+	langFilter    map[libpf.InterpreterType]bool
+}
+
+func (f *colasoftFilter) CPUFilter() libpf.PIDFilter { return f.targetPIDs }
+
+func (f *colasoftFilter) MemFilter() libpf.PIDFilter { return f.memTargetPIDs }
+
+func (f *colasoftFilter) ShouldProfileMem(_ libpf.PID, lang libpf.InterpreterType) bool {
+	if len(f.langFilter) == 0 {
+		// Default: only HotSpot and Golang are allowed.
+		return lang == libpf.HotSpot || lang == libpf.Golang
+	}
+	return f.langFilter[lang]
+}
+
 type (
 	Collector struct {
 		sr SymbolReporter
 
-		ctrl     *controller.Controller
-		reporter *reporter.ColaSoft
-		cfg      *controller.Config
+		ctrl            *controller.Controller
+		reporter        *reporter.ColaSoft
+		cfg             *controller.Config
+		profilingFilter *colasoftFilter
 	}
 
 	StartCfg struct {
 		Freq, OffCpuThreshold, CacheEventSTolerance int
 		Interval, CacheEventSTimeout                time.Duration
 		TargetPids, MemTargetPIDs                   map[libpf.PID]bool
+		MemProfLangFilter                           map[libpf.InterpreterType]bool
 		MemProfileBlock                             uint64
 	}
 )
@@ -47,6 +68,12 @@ func (c *Collector) Start(ctx context.Context, cfg StartCfg) error {
 		return err
 	}
 
+	filter := &colasoftFilter{
+		targetPIDs:    libpf.NewMutablePIDFilter(cfg.TargetPids),
+		memTargetPIDs: libpf.NewMutablePIDFilter(cfg.MemTargetPIDs),
+		langFilter:    cfg.MemProfLangFilter,
+	}
+
 	controllerCfg := &controller.Config{
 		MonitorInterval: time.Second * 5, ClockSyncInterval: time.Minute * 3,
 		NoKernelVersionCheck: true, ProbabilisticInterval: time.Minute,
@@ -54,8 +81,7 @@ func (c *Collector) Start(ctx context.Context, cfg StartCfg) error {
 		ReporterInterval:       cfg.Interval, SamplesPerSecond: cfg.Freq, Reporter: rpt,
 		Tracers:         "perl,php,python,hotspot,ruby,v8",
 		OffCPUThreshold: uint(cfg.OffCpuThreshold),
-		TargetPIDs:      libpf.NewMutablePIDFilter(cfg.TargetPids),
-		MemTargetPIDs:   libpf.NewMutablePIDFilter(cfg.MemTargetPIDs),
+		ProfilingFilter: filter,
 		MemProfileBlock: cfg.MemProfileBlock,
 	}
 	ctrl := controller.New(controllerCfg)
@@ -65,6 +91,7 @@ func (c *Collector) Start(ctx context.Context, cfg StartCfg) error {
 	c.ctrl = ctrl
 	c.reporter = rpt
 	c.cfg = controllerCfg
+	c.profilingFilter = filter
 	return nil
 }
 
@@ -74,7 +101,22 @@ func (c *Collector) Stop() {
 		c.ctrl = nil
 		c.reporter = nil
 		c.cfg = nil
+		c.profilingFilter = nil
 	}
+}
+
+func (c *Collector) SyncTargetPIDs(targetPIds map[libpf.PID]bool) error {
+	if c.profilingFilter != nil {
+		c.profilingFilter.targetPIDs.Update(targetPIds)
+	}
+	return nil
+}
+
+func (c *Collector) SyncMemTargetPIDs(targetPIds map[libpf.PID]bool) error {
+	if c.profilingFilter != nil {
+		c.profilingFilter.memTargetPIDs.Update(targetPIds)
+	}
+	return nil
 }
 
 func (c *Collector) SyncMemProfileBlock(memProfileBlock uint64) error {

--- a/colasoft/controller.go
+++ b/colasoft/controller.go
@@ -2,8 +2,9 @@ package colasoft
 
 import (
 	"context"
-	"github.com/toliu/opentelemetry-ebpf-profiler/libpf"
 	"time"
+
+	"github.com/toliu/opentelemetry-ebpf-profiler/libpf"
 
 	"github.com/toliu/opentelemetry-ebpf-profiler/internal/controller"
 	"github.com/toliu/opentelemetry-ebpf-profiler/reporter"
@@ -40,7 +41,8 @@ func (c *Collector) Start(ctx context.Context, cfg StartCfg) error {
 		c.Stop()
 	}
 
-	rpt, err := reporter.NewColaSoft(cfg.Freq, cfg.Interval, c.sr, c.sr.ConsumeProfilesFunc, noFrameOpSymbolReporter{c.sr}, cfg.CacheEventSTolerance, cfg.CacheEventSTimeout)
+	rpt, err := reporter.NewColaSoft(cfg.Freq, cfg.Interval, c.sr, c.sr.ConsumeProfilesFunc,
+		noFrameOpSymbolReporter{c.sr}, cfg.CacheEventSTolerance, cfg.CacheEventSTimeout)
 	if err != nil {
 		return err
 	}
@@ -52,8 +54,8 @@ func (c *Collector) Start(ctx context.Context, cfg StartCfg) error {
 		ReporterInterval:       cfg.Interval, SamplesPerSecond: cfg.Freq, Reporter: rpt,
 		Tracers:         "perl,php,python,hotspot,ruby,v8",
 		OffCPUThreshold: uint(cfg.OffCpuThreshold),
-		TargetPIDs:      cfg.TargetPids,
-		MemTargetPIDs:   cfg.MemTargetPIDs,
+		TargetPIDs:      libpf.NewMutablePIDFilter(cfg.TargetPids),
+		MemTargetPIDs:   libpf.NewMutablePIDFilter(cfg.MemTargetPIDs),
 		MemProfileBlock: cfg.MemProfileBlock,
 	}
 	ctrl := controller.New(controllerCfg)
@@ -73,15 +75,6 @@ func (c *Collector) Stop() {
 		c.reporter = nil
 		c.cfg = nil
 	}
-}
-
-func (c *Collector) SyncTargetPIDs(targetPIds map[libpf.PID]bool) error {
-	return c.ctrl.SyncTargetPIDs(targetPIds)
-}
-
-func (c *Collector) SyncMemTargetPIDs(targetPIds map[libpf.PID]bool) error {
-	c.ctrl.SyncMemTargetPIDs(targetPIds)
-	return nil
 }
 
 func (c *Collector) SyncMemProfileBlock(memProfileBlock uint64) error {

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -43,8 +43,7 @@ type Config struct {
 
 	Fs *flag.FlagSet
 
-	TargetPIDs      libpf.MutablePIDFilter
-	MemTargetPIDs   libpf.MutablePIDFilter
+	ProfilingFilter libpf.ProcessFilter
 	MemProfileBlock uint64
 }
 

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/toliu/opentelemetry-ebpf-profiler/libpf"
 	"runtime"
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/toliu/opentelemetry-ebpf-profiler/libpf"
 
 	"github.com/toliu/opentelemetry-ebpf-profiler/reporter"
 	"github.com/toliu/opentelemetry-ebpf-profiler/support"
@@ -43,8 +43,8 @@ type Config struct {
 
 	Fs *flag.FlagSet
 
-	TargetPIDs      map[libpf.PID]bool
-	MemTargetPIDs   map[libpf.PID]bool
+	TargetPIDs      libpf.MutablePIDFilter
+	MemTargetPIDs   libpf.MutablePIDFilter
 	MemProfileBlock uint64
 }
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -3,7 +3,6 @@ package controller // import "github.com/toliu/opentelemetry-ebpf-profiler/inter
 import (
 	"context"
 	"fmt"
-	"github.com/toliu/opentelemetry-ebpf-profiler/libpf"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -86,8 +85,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		ProbabilisticInterval:  c.config.ProbabilisticInterval,
 		ProbabilisticThreshold: c.config.ProbabilisticThreshold,
 		OffCPUThreshold:        uint32(c.config.OffCPUThreshold),
-		TargetPIDs:             c.config.TargetPIDs,
-		MemTargetPIDs:          c.config.MemTargetPIDs,
+		ProfilingFilter:        c.config.ProfilingFilter,
 		MemProfileBlock:        c.config.MemProfileBlock,
 	})
 	if err != nil {
@@ -160,15 +158,6 @@ func (c *Controller) Shutdown() {
 	if c.tracer != nil {
 		c.tracer.Close()
 	}
-}
-
-func (c *Controller) SyncTargetPIDs(targetPids map[libpf.PID]bool) error {
-	c.config.TargetPIDs.Update(targetPids)
-	return nil
-}
-
-func (c *Controller) SyncMemTargetPIDs(targetPids map[libpf.PID]bool) {
-	c.config.MemTargetPIDs.Update(targetPids)
 }
 
 func (c *Controller) SyncMemProfileBlock(memProfileBlock uint64) error {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -87,6 +87,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		ProbabilisticThreshold: c.config.ProbabilisticThreshold,
 		OffCPUThreshold:        uint32(c.config.OffCPUThreshold),
 		TargetPIDs:             c.config.TargetPIDs,
+		MemTargetPIDs:          c.config.MemTargetPIDs,
 		MemProfileBlock:        c.config.MemProfileBlock,
 	})
 	if err != nil {
@@ -119,7 +120,6 @@ func (c *Controller) Start(ctx context.Context) error {
 	}
 
 	if c.config.MemProfileBlock > 0 {
-		trc.SyncMemProfileTargetPids(c.config.MemTargetPIDs)
 		_ = trc.SyncMemProfileBlock(c.config.MemProfileBlock)
 	}
 
@@ -163,11 +163,12 @@ func (c *Controller) Shutdown() {
 }
 
 func (c *Controller) SyncTargetPIDs(targetPids map[libpf.PID]bool) error {
-	return c.tracer.SyncTargetPIDs(targetPids)
+	c.config.TargetPIDs.Update(targetPids)
+	return nil
 }
 
 func (c *Controller) SyncMemTargetPIDs(targetPids map[libpf.PID]bool) {
-	c.tracer.SyncMemProfileTargetPids(targetPids)
+	c.config.MemTargetPIDs.Update(targetPids)
 }
 
 func (c *Controller) SyncMemProfileBlock(memProfileBlock uint64) error {

--- a/libpf/pid_filter.go
+++ b/libpf/pid_filter.go
@@ -1,0 +1,94 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package libpf
+
+import (
+	"maps"
+	"sync"
+)
+
+// PIDFilter is a read-only view of a set of PIDs used for filtering.
+// Consumers that only need to read the current PID set accept this interface.
+type PIDFilter interface {
+	Snapshot() map[PID]bool
+}
+
+// MutablePIDFilter extends PIDFilter with the ability to update the set
+// and subscribe to changes. Only the top-level writer should hold this.
+type MutablePIDFilter interface {
+	PIDFilter
+	Update(newPids map[PID]bool)
+	OnChange(fn func(map[PID]bool))
+}
+
+// ApplyFilterOnChange initializes a consumer from filter and subscribes to
+// future updates. It calls fn immediately with the current snapshot, and if
+// filter is a MutablePIDFilter, registers fn as an OnChange listener.
+func ApplyFilterOnChange(filter PIDFilter, fn func(map[PID]bool)) {
+	fn(filter.Snapshot())
+	if mf, ok := filter.(MutablePIDFilter); ok {
+		mf.OnChange(fn)
+	}
+}
+
+// livePIDSet is the concrete thread-safe implementation of MutablePIDFilter.
+type livePIDSet struct {
+	mu       sync.RWMutex
+	pids     map[PID]bool
+	onChange []func(map[PID]bool)
+}
+
+var _ MutablePIDFilter = (*livePIDSet)(nil)
+
+// NewMutablePIDFilter creates a new MutablePIDFilter with the given initial PIDs.
+func NewMutablePIDFilter(initial map[PID]bool) MutablePIDFilter {
+	if initial == nil {
+		initial = make(map[PID]bool)
+	}
+	return &livePIDSet{pids: initial}
+}
+
+// Snapshot returns a shallow copy of the current PID set.
+func (s *livePIDSet) Snapshot() map[PID]bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	cp := make(map[PID]bool, len(s.pids))
+	for k, v := range s.pids {
+		cp[k] = v
+	}
+	return cp
+}
+
+// OnChange registers a callback that fires when the PID set actually
+// changes via Update(). If Update() is called with the same PIDs, the
+// callback is not invoked. Callbacks are invoked outside the lock.
+func (s *livePIDSet) OnChange(fn func(map[PID]bool)) {
+	s.mu.Lock()
+	s.onChange = append(s.onChange, fn)
+	s.mu.Unlock()
+}
+
+// Update atomically replaces the PID set and notifies all subscribers.
+// If the new PID set is equal to the current set, no notification is sent.
+// Callbacks are invoked with the new PID set, outside the lock.
+func (s *livePIDSet) Update(newPids map[PID]bool) {
+	if newPids == nil {
+		newPids = make(map[PID]bool)
+	}
+	s.mu.Lock()
+
+	if maps.Equal(s.pids, newPids) {
+		s.mu.Unlock()
+		return
+	}
+
+	s.pids = newPids
+	listeners := make([]func(map[PID]bool), len(s.onChange))
+	copy(listeners, s.onChange)
+	s.mu.Unlock()
+
+	for _, fn := range listeners {
+		fn(newPids)
+	}
+}

--- a/libpf/profiling_filter.go
+++ b/libpf/profiling_filter.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package libpf
+
+// ProcessFilter is the decision-making interface for profiling policies.
+// The core calls these methods but does NOT implement them — the top-level
+// application provides the implementation, enabling pluggable filtering
+// without modifying the core.
+type ProcessFilter interface {
+	// CPUFilter returns the PID filter for CPU profiling (eBPF map filtering).
+	CPUFilter() PIDFilter
+
+	// MemFilter returns the PID filter for memory profiling iteration.
+	MemFilter() PIDFilter
+
+	// ShouldProfileMem determines whether to start memory profiling hooks
+	// for the given process and its detected runtime language.
+	ShouldProfileMem(pid PID, lang InterpreterType) bool
+}

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -66,7 +66,7 @@ var (
 // implementation.
 func New(ctx context.Context, includeTracers types.IncludedTracers, monitorInterval time.Duration,
 	ebpf pmebpf.EbpfHandler, fileIDMapper FileIDMapper, symbolReporter reporter.SymbolReporter,
-	sdp nativeunwind.StackDeltaProvider, filterErrorFrames bool, targetPids map[libpf.PID]bool) (*ProcessManager, error) {
+	sdp nativeunwind.StackDeltaProvider, filterErrorFrames bool, targetPIDs libpf.PIDFilter) (*ProcessManager, error) {
 	if fileIDMapper == nil {
 		var err error
 		fileIDMapper, err = newFileIDMapper(lruFileIDCacheSize)
@@ -101,7 +101,14 @@ func New(ctx context.Context, includeTracers types.IncludedTracers, monitorInter
 		reporter:                 symbolReporter,
 		metricsAddSlice:          metrics.AddSlice,
 		filterErrorFrames:        filterErrorFrames,
-		targetPids:               targetPids,
+	}
+
+	if targetPIDs != nil {
+		libpf.ApplyFilterOnChange(targetPIDs, func(pids map[libpf.PID]bool) {
+			if err := ebpf.ConfigureTargetPIDs(pids); err != nil {
+				log.Warnf("Failed to configure target PIDs: %v", err)
+			}
+		})
 	}
 
 	collectInterpreterMetrics(ctx, pm, monitorInterval)
@@ -321,17 +328,6 @@ func (pm *ProcessManager) MaybeNotifyAPMAgent(
 	}
 
 	return serviceName
-}
-
-func (pm *ProcessManager) ConfigureTargetPids() error {
-	pm.mu.Lock()
-	defer pm.mu.Unlock()
-	return pm.ebpf.ConfigureTargetPIDs(pm.targetPids)
-}
-
-func (pm *ProcessManager) SyncTargetPids(targetPids map[libpf.PID]bool) error {
-	pm.targetPids = targetPids
-	return pm.ConfigureTargetPids()
 }
 
 // AddSynthIntervalData adds synthetic stack deltas to the manager. This is useful for cases where

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -66,7 +66,7 @@ var (
 // implementation.
 func New(ctx context.Context, includeTracers types.IncludedTracers, monitorInterval time.Duration,
 	ebpf pmebpf.EbpfHandler, fileIDMapper FileIDMapper, symbolReporter reporter.SymbolReporter,
-	sdp nativeunwind.StackDeltaProvider, filterErrorFrames bool, targetPIDs libpf.PIDFilter) (*ProcessManager, error) {
+	sdp nativeunwind.StackDeltaProvider, filterErrorFrames bool, filter libpf.ProcessFilter) (*ProcessManager, error) {
 	if fileIDMapper == nil {
 		var err error
 		fileIDMapper, err = newFileIDMapper(lruFileIDCacheSize)
@@ -103,8 +103,8 @@ func New(ctx context.Context, includeTracers types.IncludedTracers, monitorInter
 		filterErrorFrames:        filterErrorFrames,
 	}
 
-	if targetPIDs != nil {
-		libpf.ApplyFilterOnChange(targetPIDs, func(pids map[libpf.PID]bool) {
+	if filter != nil {
+		libpf.ApplyFilterOnChange(filter.CPUFilter(), func(pids map[libpf.PID]bool) {
 			if err := ebpf.ConfigureTargetPIDs(pids); err != nil {
 				log.Warnf("Failed to configure target PIDs: %v", err)
 			}

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -243,10 +243,10 @@ func (mockup *ebpfMapsMockup) DeletePidPageMappingInfo(_ libpf.PID, prefixes []l
 	return len(prefixes), nil
 }
 
-func (mockup *ebpfMapsMockup) CollectMetrics() []metrics.Metric        { return []metrics.Metric{} }
-func (mockup *ebpfMapsMockup) SupportsGenericBatchOperations() bool    { return false }
-func (mockup *ebpfMapsMockup) SupportsLPMTrieBatchOperations() bool    { return false }
-func (mockup *ebpfMapsMockup) ConfigureTargetPIDs(_ []libpf.PID) error { return nil }
+func (mockup *ebpfMapsMockup) CollectMetrics() []metrics.Metric               { return []metrics.Metric{} }
+func (mockup *ebpfMapsMockup) SupportsGenericBatchOperations() bool           { return false }
+func (mockup *ebpfMapsMockup) SupportsLPMTrieBatchOperations() bool           { return false }
+func (mockup *ebpfMapsMockup) ConfigureTargetPIDs(_ map[libpf.PID]bool) error { return nil }
 
 type symbolReporterMockup struct{}
 
@@ -319,7 +319,7 @@ func TestInterpreterConvertTrace(t *testing.T) {
 				nil,
 				&symbolReporterMockup{},
 				nil,
-				true, []libpf.PID{})
+				true, nil)
 			require.NoError(t, err)
 
 			newTrace := manager.ConvertTrace(testcase.trace)
@@ -404,7 +404,7 @@ func TestNewMapping(t *testing.T) {
 				NewMapFileIDMapper(),
 				symRepMockup,
 				&dummyProvider,
-				true, []libpf.PID{})
+				true, nil)
 			require.NoError(t, err)
 
 			// Replace the internal hooks for the tests. These hooks catch the
@@ -589,7 +589,7 @@ func TestProcExit(t *testing.T) {
 				NewMapFileIDMapper(),
 				repMockup,
 				&dummyProvider,
-				true, []libpf.PID{})
+				true, nil)
 			require.NoError(t, err)
 			defer cancel()
 

--- a/processmanager/types.go
+++ b/processmanager/types.go
@@ -96,8 +96,6 @@ type ProcessManager struct {
 
 	// filterErrorFrames determines whether error frames are dropped by `ConvertTrace`.
 	filterErrorFrames bool
-
-	targetPids map[libpf.PID]bool
 }
 
 // Mapping represents an executable memory mapping of a process.

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -5,7 +5,6 @@ package reporter // import "github.com/toliu/opentelemetry-ebpf-profiler/reporte
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	lru "github.com/elastic/go-freelru"
@@ -49,8 +48,6 @@ type baseReporter struct {
 
 	// memAddr-hash
 	addrHashMap map[int64]libpf.TraceHash
-
-	targetPids sync.Map
 }
 
 func (b *baseReporter) Stop() {
@@ -266,16 +263,4 @@ func (b *baseReporter) FrameMetadata(args *FrameMetadataArgs) {
 	}
 	mu := xsync.NewRWMutex(v)
 	b.pdata.Frames.Add(fileID, &mu)
-}
-
-func (b *baseReporter) SyncTargetPids(targetPids map[libpf.PID]struct{}) {
-	b.targetPids.Range(func(k, v interface{}) bool {
-		if _, ok := targetPids[k.(libpf.PID)]; !ok {
-			b.targetPids.Delete(k)
-		}
-		return true
-	})
-	for pid, v := range targetPids {
-		b.targetPids.Store(pid, v)
-	}
 }

--- a/reporter/memreporter.go
+++ b/reporter/memreporter.go
@@ -1,7 +1,6 @@
 package reporter
 
 import (
-	"github.com/toliu/opentelemetry-ebpf-profiler/libpf"
 	"github.com/toliu/opentelemetry-ebpf-profiler/reporter/hotspotmem"
 )
 
@@ -10,8 +9,4 @@ type HotspotMemReporter interface {
 	StartHotspotMemProfiling(cfg *hotspotmem.OTLPProfilerConfig) error
 	StopHotspotMemProfiling(pid int)
 	SyncHotspotMemProfilingCfg(cfg *hotspotmem.OTLPProfilerConfig)
-}
-
-type MemReporter interface {
-	SyncTargetPids(targetPids map[libpf.PID]struct{})
 }

--- a/tools/coredump/ebpfmaps.go
+++ b/tools/coredump/ebpfmaps.go
@@ -258,6 +258,6 @@ func (emc *ebpfMapsCoredump) SupportsLPMTrieBatchOperations() bool {
 	return false
 }
 
-func (emc *ebpfMapsCoredump) ConfigureTargetPIDs(pids []libpf.PID) error {
+func (emc *ebpfMapsCoredump) ConfigureTargetPIDs(pids map[libpf.PID]bool) error {
 	return nil
 }

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -129,7 +129,7 @@ type Tracer struct {
 
 	// probabilisticThreshold holds the threshold for probabilistic profiling.
 	probabilisticThreshold uint
-	memProfileHooks        xsync.RWMutex[map[libpf.PID][]*link.Link]
+	memProfileHooks        xsync.RWMutex[map[libpf.PID]*memProfileEntry]
 	memProfileBlock        atomic.Uint64
 	profilingFilter        libpf.ProcessFilter
 }
@@ -323,7 +323,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 	}
 
 	perfEventList := []*perf.Event{}
-	memProfileHooks := map[libpf.PID][]*link.Link{}
+	memProfileHooks := map[libpf.PID]*memProfileEntry{}
 
 	t := &Tracer{
 		processManager:         processManager,
@@ -364,21 +364,23 @@ func (t *Tracer) Close() {
 	*events = nil
 	t.perfEntrypoints.WUnlock(&events)
 
-	memProfileHooks := t.memProfileHooks.WLock()
-	for pid, links := range *memProfileHooks {
-		if links == nil {
+	mh := t.memProfileHooks.WLock()
+	for pid, entry := range *mh {
+		if entry == nil || entry.links == nil {
 			if r, ok := t.reporter.(reporter.HotspotMemReporter); ok {
 				r.StopHotspotMemProfiling(int(pid))
 			}
 		}
-		for _, l := range links {
-			if err := (*l).Close(); err != nil {
-				log.Errorf("Failed to close mem profile hook: %v", err)
+		if entry != nil {
+			for _, l := range entry.links {
+				if err := (*l).Close(); err != nil {
+					log.Errorf("Failed to close mem profile hook: %v", err)
+				}
 			}
 		}
 	}
-	memProfileHooks = nil
-	t.memProfileHooks.WUnlock(&memProfileHooks)
+	mh = nil
+	t.memProfileHooks.WUnlock(&mh)
 
 	// Avoid resource leakage by closing all kernel hooks.
 	for hookPoint, hook := range t.hooks {

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -131,7 +131,7 @@ type Tracer struct {
 	probabilisticThreshold uint
 	memProfileHooks        xsync.RWMutex[map[libpf.PID][]*link.Link]
 	memProfileBlock        atomic.Uint64
-	memProfileTargetPids   xsync.RWMutex[map[libpf.PID]bool]
+	profilingFilter        libpf.ProcessFilter
 }
 
 type Config struct {
@@ -161,9 +161,8 @@ type Config struct {
 	OffCPUThreshold uint32
 	// MemProfile switch memprofile
 	// TargetPIDs is the PIDFilter for CPU profiling target PID filtering.
-	TargetPIDs libpf.PIDFilter
-	// MemTargetPIDs is the PIDFilter for memory profiling target PID filtering.
-	MemTargetPIDs libpf.PIDFilter
+	// ProfilingFilter defines the profiling policy (PID filters, language rules).
+	ProfilingFilter libpf.ProcessFilter
 	// 每分配MemProfileBlock字节的内存就采集一次
 	MemProfileBlock uint64
 }
@@ -306,7 +305,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 
 	processManager, err := pm.New(ctx, cfg.IncludeTracers, cfg.Intervals.MonitorInterval(),
 		ebpfHandler, nil, cfg.Reporter, elfunwindinfo.NewStackDeltaProvider(),
-		cfg.FilterErrorFrames, cfg.TargetPIDs)
+		cfg.FilterErrorFrames, cfg.ProfilingFilter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processManager: %v", err)
 	}
@@ -344,17 +343,9 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 		probabilisticInterval:  cfg.ProbabilisticInterval,
 		probabilisticThreshold: cfg.ProbabilisticThreshold,
 		memProfileHooks:        xsync.NewRWMutex(memProfileHooks),
-		memProfileTargetPids:   xsync.NewRWMutex(make(map[libpf.PID]bool)),
 	}
 
-	// Subscribe to MemTargetPIDs changes for dynamic memory profiling target updates.
-	if cfg.MemTargetPIDs != nil {
-		libpf.ApplyFilterOnChange(cfg.MemTargetPIDs, func(pids map[libpf.PID]bool) {
-			mp := t.memProfileTargetPids.WLock()
-			*mp = pids
-			t.memProfileTargetPids.WUnlock(&mp)
-		})
-	}
+	t.profilingFilter = cfg.ProfilingFilter
 	return t, nil
 }
 

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -14,7 +14,6 @@ import (
 	"math/rand/v2"
 	"sort"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -132,7 +131,7 @@ type Tracer struct {
 	probabilisticThreshold uint
 	memProfileHooks        xsync.RWMutex[map[libpf.PID][]*link.Link]
 	memProfileBlock        atomic.Uint64
-	memProfileTargetPids   sync.Map
+	memProfileTargetPids   xsync.RWMutex[map[libpf.PID]bool]
 }
 
 type Config struct {
@@ -161,8 +160,10 @@ type Config struct {
 	// OffCPUThreshold is the user defined threshold for off-cpu profiling.
 	OffCPUThreshold uint32
 	// MemProfile switch memprofile
-	// TargetPIDs is a list of PIDs to target for profiling.
-	TargetPIDs map[libpf.PID]bool
+	// TargetPIDs is the PIDFilter for CPU profiling target PID filtering.
+	TargetPIDs libpf.PIDFilter
+	// MemTargetPIDs is the PIDFilter for memory profiling target PID filtering.
+	MemTargetPIDs libpf.PIDFilter
 	// 每分配MemProfileBlock字节的内存就采集一次
 	MemProfileBlock uint64
 }
@@ -309,9 +310,6 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processManager: %v", err)
 	}
-	if err = processManager.ConfigureTargetPids(); err != nil {
-		return nil, fmt.Errorf("failed to configure target PIDs: %v", err)
-	}
 
 	const fallbackSymbolsCacheSize = 16384
 
@@ -328,7 +326,7 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 	perfEventList := []*perf.Event{}
 	memProfileHooks := map[libpf.PID][]*link.Link{}
 
-	return &Tracer{
+	t := &Tracer{
 		processManager:         processManager,
 		kernelSymbols:          kernelSymbols,
 		kernelModules:          kernelModules,
@@ -346,8 +344,18 @@ func NewTracer(ctx context.Context, cfg *Config) (*Tracer, error) {
 		probabilisticInterval:  cfg.ProbabilisticInterval,
 		probabilisticThreshold: cfg.ProbabilisticThreshold,
 		memProfileHooks:        xsync.NewRWMutex(memProfileHooks),
-		memProfileTargetPids:   sync.Map{},
-	}, nil
+		memProfileTargetPids:   xsync.NewRWMutex(make(map[libpf.PID]bool)),
+	}
+
+	// Subscribe to MemTargetPIDs changes for dynamic memory profiling target updates.
+	if cfg.MemTargetPIDs != nil {
+		libpf.ApplyFilterOnChange(cfg.MemTargetPIDs, func(pids map[libpf.PID]bool) {
+			mp := t.memProfileTargetPids.WLock()
+			*mp = pids
+			t.memProfileTargetPids.WUnlock(&mp)
+		})
+	}
+	return t, nil
 }
 
 // Close provides functionality for Tracer to perform cleanup tasks.
@@ -1409,8 +1417,4 @@ func (t *Tracer) StartOffCPUProfiling() error {
 // TraceProcessor gets the trace processor.
 func (t *Tracer) TraceProcessor() tracehandler.TraceProcessor {
 	return t.processManager
-}
-
-func (t *Tracer) SyncTargetPIDs(targetPids map[libpf.PID]bool) error {
-	return t.processManager.SyncTargetPids(targetPids)
 }

--- a/tracer/uprobe.go
+++ b/tracer/uprobe.go
@@ -283,37 +283,29 @@ func (t *Tracer) monitorMemProfilePids(keys *[]uint32) {
 	if t.memProfileBlock.Load() == 0 {
 		return
 	}
-	var memProfileTargetPids []libpf.PID
-	t.memProfileTargetPids.Range(func(k, v interface{}) bool {
-		pid := k.(libpf.PID)
-		if pid == 0 {
-			return true
-		}
-		if add, ok := v.(bool); ok {
-			if !add {
-				t.detachMemProfile(pid)
-				t.memProfileTargetPids.Delete(k)
-			} else {
-				memProfileTargetPids = append(memProfileTargetPids, pid)
-				if t.hasMemProfileHooks(pid) {
-					return true
-				}
-				*keys = append(*keys, pid.Hash32())
-				if err := t.triggerMemProfile(process.New(pid)); err != nil {
-					log.Debugf("failed to trigger memprofile for process %v: %v", k, err)
-				}
-			}
-		}
-		return true
-	})
-	log.Debugf("apply mem profiling target pids: %v", memProfileTargetPids)
-}
 
-func (t *Tracer) SyncMemProfileTargetPids(targetPids map[libpf.PID]bool) {
-	t.memProfileTargetPids.Clear()
-	for pid, add := range targetPids {
-		t.memProfileTargetPids.Store(pid, add)
+	pids := t.memProfileTargetPids.RLock()
+	defer t.memProfileTargetPids.RUnlock(&pids)
+
+	var memProfileTargetPids []libpf.PID
+	for pid, add := range *pids {
+		if pid == 0 {
+			continue
+		}
+		if add {
+			memProfileTargetPids = append(memProfileTargetPids, pid)
+			if t.hasMemProfileHooks(pid) {
+				continue
+			}
+			*keys = append(*keys, pid.Hash32())
+			if err := t.triggerMemProfile(process.New(pid)); err != nil {
+				log.Debugf("failed to trigger memprofile for process %v: %v", pid, err)
+			}
+		} else {
+			t.detachMemProfile(pid)
+		}
 	}
+	log.Debugf("apply mem profiling target pids: %v", memProfileTargetPids)
 }
 
 func (t *Tracer) SyncMemProfileBlock(block uint64) error {

--- a/tracer/uprobe.go
+++ b/tracer/uprobe.go
@@ -12,12 +12,12 @@ import (
 	cebpf "github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 	log "github.com/sirupsen/logrus"
-
 	"github.com/toliu/opentelemetry-ebpf-profiler/libpf"
 	"github.com/toliu/opentelemetry-ebpf-profiler/process"
 	"github.com/toliu/opentelemetry-ebpf-profiler/processmanager"
 	"github.com/toliu/opentelemetry-ebpf-profiler/reporter"
 	"github.com/toliu/opentelemetry-ebpf-profiler/reporter/hotspotmem"
+	"golang.org/x/exp/maps"
 )
 
 // #include "../support/ebpf/types.h"
@@ -36,6 +36,15 @@ type uprobe struct {
 	canFail             bool
 	pid                 int
 	opts                *link.UprobeOptions
+}
+
+const maxMemProfileRetries = 5
+
+// memProfileEntry tracks per-PID memory profiling hook state and retry count.
+type memProfileEntry struct {
+	links     []*link.Link
+	failCount int
+	hooked    bool // true if hooks were successfully attached at least once
 }
 
 // loadUProbeUnwinders reuses large parts of loadPerfUnwinders. By default all eBPF programs
@@ -111,21 +120,23 @@ func (t *Tracer) AttachUProbes(u *uprobe) ([]*link.Link, error) {
 	return resLinks, nil
 }
 
-func (t *Tracer) detachMemProfile(pid libpf.PID) {
-	memProfileHooks := t.memProfileHooks.WLock()
-	if links, ok := (*memProfileHooks)[pid]; ok {
-		for _, _link := range links {
-			if e := (*_link).Close(); e != nil {
-				log.Debugf("failed to close memprofile link{ pid:%d, link:%v, err: %v", pid, _link, e)
+func (t *Tracer) detachMemProfile(pids ...libpf.PID) {
+	for _, pid := range pids {
+		mh := t.memProfileHooks.WLock()
+		if entry, ok := (*mh)[pid]; ok && entry.links != nil {
+			for _, _link := range entry.links {
+				if e := (*_link).Close(); e != nil {
+					log.Debugf("failed to close memprofile link{ pid:%d, link:%v, err: %v", pid, _link, e)
+				}
 			}
 		}
+		delete(*mh, pid)
+		t.memProfileHooks.WUnlock(&mh)
+		if r, ok := t.reporter.(reporter.HotspotMemReporter); ok {
+			r.StopHotspotMemProfiling(int(pid))
+		}
+		log.Tracef("detachMemProfile for pid %v", pid)
 	}
-	delete(*memProfileHooks, pid)
-	t.memProfileHooks.WUnlock(&memProfileHooks)
-	if r, ok := t.reporter.(reporter.HotspotMemReporter); ok {
-		r.StopHotspotMemProfiling(int(pid))
-	}
-	log.Tracef("detachMemProfile for pid %v", pid)
 }
 
 // StartCLikeMemProfiling starts mem profiling for c/c++/rust by attaching the programs to the hooks.
@@ -196,16 +207,20 @@ func (t *Tracer) StartPythonMemProfiling(exec *link.Executable, _ *processmanage
 }
 
 func (t *Tracer) hasMemProfileHooks(pid libpf.PID) bool {
-	memProfileHooks := t.memProfileHooks.RLock()
-	_, exist := (*memProfileHooks)[pid]
-	t.memProfileHooks.RUnlock(&memProfileHooks)
-	return exist
+	mh := t.memProfileHooks.RLock()
+	entry := (*mh)[pid]
+	t.memProfileHooks.RUnlock(&mh)
+	if entry == nil {
+		return false
+	}
+	// Hook was successfully attached, or we've given up after max retries.
+	return entry.hooked || entry.failCount >= maxMemProfileRetries
 }
 
 func (t *Tracer) updateMemProfileHooks(pid libpf.PID, links []*link.Link) {
-	memProfileHooks := t.memProfileHooks.WLock()
-	(*memProfileHooks)[pid] = links
-	t.memProfileHooks.WUnlock(&memProfileHooks)
+	mh := t.memProfileHooks.WLock()
+	(*mh)[pid] = &memProfileEntry{links: links, hooked: true}
+	t.memProfileHooks.WUnlock(&mh)
 }
 
 func (t *Tracer) triggerMemProfile(p process.Process) error {
@@ -236,7 +251,7 @@ func (t *Tracer) triggerMemProfile(p process.Process) error {
 			t.detachMemProfile(pid)
 			return err
 		}
-		t.updateMemProfileHooks(pid, nil)
+		t.updateMemProfileHooks(pid, []*link.Link{})
 		return nil
 	case libpf.Python:
 		startProfiling = t.StartPythonMemProfiling
@@ -292,25 +307,43 @@ func (t *Tracer) monitorMemProfilePids(keys *[]uint32) {
 	// Allocates a full copy each cycle — acceptable for small PID sets.
 	pids := t.profilingFilter.MemFilter().Snapshot()
 
-	var memProfileTargetPids []libpf.PID
+	currentTargetPids := map[libpf.PID]struct{}{}
 	for pid, add := range pids {
 		if pid == 0 {
 			continue
 		}
-		if add {
-			memProfileTargetPids = append(memProfileTargetPids, pid)
-			if t.hasMemProfileHooks(pid) {
-				continue
-			}
-			*keys = append(*keys, pid.Hash32())
-			if err := t.triggerMemProfile(process.New(pid)); err != nil {
-				log.Debugf("failed to trigger memprofile for process %v: %v", pid, err)
-			}
-		} else {
+		if !add {
 			t.detachMemProfile(pid)
+			continue
+		}
+		currentTargetPids[pid] = struct{}{}
+		if t.hasMemProfileHooks(pid) {
+			continue
+		}
+		*keys = append(*keys, pid.Hash32())
+		if err := t.triggerMemProfile(process.New(pid)); err != nil {
+			mh := t.memProfileHooks.WLock()
+			entry := (*mh)[pid]
+			if entry == nil {
+				entry = &memProfileEntry{}
+				(*mh)[pid] = entry
+			}
+			entry.failCount++
+			log.Debugf("failed to trigger memprofile for process %v (attempt %d/%d): %v",
+				pid, entry.failCount, maxMemProfileRetries, err)
+			t.memProfileHooks.WUnlock(&mh)
 		}
 	}
-	log.Debugf("apply mem profiling target pids: %v", memProfileTargetPids)
+	log.Debugf("apply mem profiling target pids: %v", maps.Keys(currentTargetPids))
+	var deletedPids []libpf.PID
+	mh := t.memProfileHooks.RLock()
+	for pid := range *mh {
+		if _, has := currentTargetPids[pid]; !has {
+			deletedPids = append(deletedPids, pid)
+		}
+	}
+	t.memProfileHooks.RUnlock(&mh)
+	t.detachMemProfile(deletedPids...)
 }
 
 func (t *Tracer) SyncMemProfileBlock(block uint64) error {

--- a/tracer/uprobe.go
+++ b/tracer/uprobe.go
@@ -217,6 +217,11 @@ func (t *Tracer) triggerMemProfile(p process.Process) error {
 	if memProfileInfo == nil {
 		return fmt.Errorf("unable to start memprofile with pid: %d, can not find MemProfile MetaInfo", pid)
 	}
+
+	if t.profilingFilter != nil && !t.profilingFilter.ShouldProfileMem(pid, memProfileInfo.Lang) {
+		return nil
+	}
+
 	var startProfiling func(exec *link.Executable, info *processmanager.MemProfileMeta, pid int, opts *link.UprobeOptions) ([]*link.Link, error)
 	var exec *link.Executable
 	var execPath string
@@ -284,11 +289,11 @@ func (t *Tracer) monitorMemProfilePids(keys *[]uint32) {
 		return
 	}
 
-	pids := t.memProfileTargetPids.RLock()
-	defer t.memProfileTargetPids.RUnlock(&pids)
+	// Allocates a full copy each cycle — acceptable for small PID sets.
+	pids := t.profilingFilter.MemFilter().Snapshot()
 
 	var memProfileTargetPids []libpf.PID
-	for pid, add := range *pids {
+	for pid, add := range pids {
 		if pid == 0 {
 			continue
 		}


### PR DESCRIPTION
# PR: Profiling 过滤架构重构

## Summary

将 profiling 的 PID 过滤和语言过滤从分散在 4 层的硬编码实现，重构为 `libpf` 定义的 3 个接口，由顶层 `colasoft` 实现。核心层只依赖只读接口，过滤策略完全由上层定制。同时增加了 uprobe 挂载失败的重试上限，防止无限重试消耗资源。

## Commits

| Commit | 说明 |
|---|---|
| `4a1fa6b` | fix: profiling进程过滤锁逻辑优化 |
| `e7a66ac` | feat: 内存profiling支持按语言过滤，默认不挂c/python的进程 |
| `3914cf5` | feat: 内存profiling uprobe挂载失败增加重试上限 |

## Files Changed

```
13 files, +277 / -138 lines
```

| File | +/− | 说明 |
|---|---|---|
| `libpf/pid_filter.go` | +94 | **新建** — PIDFilter/MutablePIDFilter 接口 + livePIDSet 实现 + ApplyFilterOnChange 辅助函数 |
| `libpf/profiling_filter.go` | +20 | **新建** — ProcessFilter 接口（CPU/Mem PID 过滤 + 语言过滤） |
| `colasoft/controller.go` | +44/−9 | 实现 colasoftFilter(ProcessFilter)，集中所有过滤策略 |
| `tracer/uprobe.go` | ++/− | memProfileEntry 合并 hooks+重试计数，maxRetries=5 |
| `tracer/tracer.go` | ++/−25 | Config 3 字段 → 1 字段 ProfilingFilter，移除 sync.Map |
| `internal/controller/config.go` | +2/−3 | Config 3 字段 → ProfilingFilter |
| `internal/controller/controller.go` | +1/−11 | 透传 ProfilingFilter，移除死代码 |
| `processmanager/manager.go` | +9/−13 | New() 参数改为 ProcessFilter，内置 ApplyFilterOnChange |
| `processmanager/types.go` | −2 | 移除 targetPids 字段 |
| `reporter/base_reporter.go` | −15 | 移除死代码 targetPids + SyncTargetPids |
| `reporter/memreporter.go` | −5 | 移除死代码 MemReporter 接口 |
| `tools/coredump/ebpfmaps.go` | +1/−1 | 修复 ConfigureTargetPIDs 签名不匹配 |
| `processmanager/manager_test.go` | +7/−7 | 适配新签名 |

## 架构设计

### 改前 vs 改后

```
改前:
tracer.Config {
    TargetPIDs      *LivePIDSet      ← 3 个独立字段端到端透传
    MemTargetPIDs   *LivePIDSet
    MemProfLangFilter map[...]bool
}

改后:
tracer.Config {
    ProfilingFilter  libpf.ProcessFilter  ← 1 个接口
}
```

### 接口定义

```go
// libpf/pid_filter.go
type PIDFilter interface {
    Snapshot() map[PID]bool
}

type MutablePIDFilter interface {
    PIDFilter
    Update(newPids map[PID]bool)
    OnChange(fn func(map[PID]bool))
}

// libpf/profiling_filter.go
type ProcessFilter interface {
    CPUFilter() PIDFilter
    MemFilter() PIDFilter
    ShouldProfileMem(pid PID, lang InterpreterType) bool
}
```

### 各层可见面

```
colasoft (持有 MutablePIDFilter, 实现 ProcessFilter)
  │ MutablePIDFilter.Update()
  ▼
controller.Config ── ProcessFilter ──┐
tracer.Config ───── ProcessFilter ──┤  (只读接口)
processmanager ──── ProcessFilter ──┘
```

### ApplyFilterOnChange — 消除样板代码

```go
// 改前 (每处 10+ 行):
if filter != nil {
    fn(filter.Snapshot())
    if mf, ok := filter.(MutablePIDFilter); ok {
        mf.OnChange(fn)
    }
}

// 改后 (1 行):
libpf.ApplyFilterOnChange(filter, fn)
```

## 具体改进

### 1. 死代码清理 (~30 行)

- `processmanager.{ConfigureTargetPids, SyncTargetPids}` — 功能内化到 New()
- `tracer.{SyncTargetPIDs, SyncMemProfileTargetPids}` — 透传层
- `reporter.baseReporter.{targetPids, SyncTargetPids}` — 从未被调用
- `reporter.MemReporter` — 从未被调用
- `controller.SyncTargetPIDs/SyncMemTargetPIDs` — 无 callers

### 2. Data race 修复

`processmanager.SyncTargetPids` 旧代码:
```go
pm.targetPids = targetPids           // ← 无锁写入
return pm.ConfigureTargetPids()       // ← 锁内读取
```

修复: livePIDSet.Update() 原子替换 + 脏检查 + 回调在锁外通知。

### 3. memProfileEntry 合并双锁

```go
// 改前: 2 个 xsync.RWMutex
memProfileHooks        xsync.RWMutex[map[libpf.PID][]*link.Link]
memProfileFailCount    xsync.RWMutex[map[libpf.PID]int]

// 改后: 1 个 xsync.RWMutex
memProfileHooks        xsync.RWMutex[map[libpf.PID]*memProfileEntry]

type memProfileEntry struct {
    links     []*link.Link
    failCount int
    hooked    bool
}
```

`hasMemProfileHooks()` 统一判断: `entry.hooked || entry.failCount >= 5`。

### 4. Uprobe 挂载重试上限

`monitorMemProfilePids` 每个 PID 最多重试 5 个周期，超过后跳过不再尝试，detach 时重置计数。

### 5. 语言过滤可定制

`colasoftFilter.ShouldProfileMem()` 实现:
- langFilter 为空 → 默认仅 HotSpot/Golang
- langFilter 非空 → 按显式配置

过滤策略完全由上层定义，核心无侵入。

## Test Plan

- [x] `go build ./...` 通过
- [x] `go vet ./...` 通过（仅预存 coredump unsafe.Pointer 告警）
- [x] `go test ./processmanager/` 通过
- [x] 验证 CPU profiling PID 过滤 — 传入 targetPIDs，确认 eBPF map 正确配置
- [x] 验证内存 profiling 语言过滤 — 传入 langFilter，确认 HotSpot/Go 正常、C/Python 被跳过
- [x] 验证 uprobe 重试上限 — 注入挂载失败场景，确认 5 次后跳过

## 可扩展性

对接方只需实现 `ProcessFilter` 接口即可替换所有过滤策略，无需修改 `tracer`/`processmanager`/`controller` 核心代码。

例如新增"按系统负载过滤"：
```go
func (f *customFilter) ShouldProfileMem(pid PID, lang InterpreterType) bool {
    if systemLoad() > 0.8 { return false }
    return f.langFilter[lang]
}
```